### PR TITLE
Add Farcaster Mini App support for Gaza donation platform

### DIFF
--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -1,0 +1,26 @@
+{
+  "miniapp": {
+    "version": "1",
+    "name": "Gaza Aid Platform",
+    "homeUrl": "http://localhost:3000",
+    "iconUrl": "http://localhost:3000/giraffe.png",
+    "splashImageUrl": "http://localhost:3000/giraffe.png",
+    "splashBackgroundColor": "#f3f4f6",
+    "subtitle": "Direct Crypto Donations",
+    "description": "Support Ibrahim's family in Gaza with direct cryptocurrency donations for food, rent, and medicine. 100% of your donation directly reaches them.",
+    "primaryCategory": "finance",
+    "tags": ["donation", "gaza", "aid", "crypto", "humanitarian"],
+    "heroImageUrl": "http://localhost:3000/api/images/start",
+    "tagline": "Direct Aid, Zero Admin Fees",
+    "ogTitle": "Support Ibrahim's Family in Gaza",
+    "ogDescription": "Direct cryptocurrency donations for immediate humanitarian aid",
+    "ogImageUrl": "http://localhost:3000/api/images/start",
+    "noindex": false,
+    "requiredChains": [
+      "eip155:8453"
+    ],
+    "requiredCapabilities": [
+      "wallet.sendTransaction"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Added Farcaster Mini App manifest (`public/.well-known/farcaster.json`) to enable proper integration with Farcaster clients
- Configured application metadata for Gaza Aid Platform including name, icons, and descriptions
- Set Base network (eip155:8453) as required chain and wallet.sendTransaction capability for donation functionality

## Changes
- Created `public/.well-known/farcaster.json` with complete Mini App configuration
- Includes appropriate tags, categories, and Open Graph metadata for social sharing
- Configured splash screen and branding consistent with the donation platform

## Test plan
- [ ] Verify farcaster.json is served at `/.well-known/farcaster.json` endpoint
- [ ] Test integration with Farcaster client to ensure proper app display
- [ ] Confirm donation flow works with Farcaster wallet integration

🤖 Generated with [Claude Code](https://claude.ai/code)