### PR TITLE
Update Farcaster manifest with watermelon icon and account association

### DIFF
--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -1,4 +1,9 @@
 {
+  "accountAssociation": {
+    "header": "eyJmaWQiOjY5NjAxMiwidHlwZSI6ImF1dGgiLCJrZXkiOiIweDZFMjczN2Q3QjcyNDdBMzVFZDY4NTFhNjg1YTE1NEZCQTE5RTQxRGEifQ",
+    "payload": "eyJkb21haW4iOiJmYXJjYXN0ZXItZG9uYXRlLXRvLWdhemEudmVyY2VsLmFwcCJ9",
+    "signature": "V+Wwbz4H2bUC42U9qEmXi74PY3rNvZJFxbSeqKErhcN0wShOWdWWH4eE4G1vu5qIPTgAbr9vOTJbj6BpOF0e9xw="
+  },
   "miniapp": {
     "name": "Gaza Donations - Ibrahim Friends",
     "homeUrl": "https://farcaster-donate-to-gaza.vercel.app",


### PR DESCRIPTION
## Summary
- Updated Farcaster Mini App manifest with production configuration
- Added watermelon icon as the app icon
- Changed category from finance to utility
- Updated app name to "Gaza Donations - Ibrahim Friends"
- Added accountAssociation for Farcaster domain verification

## Changes
- Added `watermelon-icon.png` to public directory
- Updated `farcaster.json` with:
  - Production URL: https://farcaster-donate-to-gaza.vercel.app
  - Watermelon icon URL
  - Simplified manifest with only essential fields
  - Account association for domain verification

## Test plan
- [ ] Verify watermelon icon displays correctly in Farcaster
- [ ] Confirm manifest is properly served at `/.well-known/farcaster.json`
- [ ] Test domain verification with accountAssociation
- [ ] Validate app loads correctly in Farcaster clients

🤖 Generated with [Claude Code](https://claude.ai/code)