### PR TITLE
feat: Add shareable frame popup post-donation with Farcaster integration

### DIFF
--- a/app/components/EnhancedDonationWidget.tsx
+++ b/app/components/EnhancedDonationWidget.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { DONATION_ADDRESS, SUPPORTED_TOKENS } from '../config';
 import sdk from '@farcaster/frame-sdk';
+import ShareDonationFrame from './ShareDonationFrame';
 
 type TransactionState = 'idle' | 'connecting' | 'switching' | 'signing' | 'pending' | 'confirmed' | 'failed';
 
@@ -16,6 +17,8 @@ export default function EnhancedDonationWidget() {
   const [copiedAddress, setCopiedAddress] = useState(false);
   const [isInFarcasterContext, setIsInFarcasterContext] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
+  const [showShareFrame, setShowShareFrame] = useState(false);
+  const [lastDonationAmount, setLastDonationAmount] = useState('');
 
   const networks = {
     base: { 
@@ -70,6 +73,7 @@ export default function EnhancedDonationWidget() {
           if (data.result) {
             if (data.result.status === '0x1') {
               setTxState('confirmed');
+              setShowShareFrame(true);
             } else {
               setTxState('failed');
               setTxError('Transaction failed on chain');
@@ -230,6 +234,7 @@ export default function EnhancedDonationWidget() {
 
       setTxHash(hash);
       setTxState('pending');
+      setLastDonationAmount(amount);
       setAmount('');
 
     } catch (error: any) {
@@ -262,7 +267,19 @@ export default function EnhancedDonationWidget() {
     : ['100', '250', '500', '1000', '2500', '5000'];
 
   return (
-    <div className="w-full max-w-lg mx-auto">
+    <>
+      {/* Share Frame Popup */}
+      {showShareFrame && walletAddress && txHash && (
+        <ShareDonationFrame
+          amount={lastDonationAmount}
+          asset={selectedToken}
+          userAddress={walletAddress}
+          txHash={txHash}
+          onClose={() => setShowShareFrame(false)}
+        />
+      )}
+
+      <div className="w-full max-w-lg mx-auto">
       {/* Context Card */}
       <div className="bg-white rounded-2xl shadow-lg p-6 mb-4 border-l-4 border-purple-500">
         <h3 className="font-bold text-gray-900 mb-2">Support Ibrahim's Family in Gaza</h3>
@@ -527,6 +544,7 @@ export default function EnhancedDonationWidget() {
         }
       `}</style>
     </div>
+    </>
   );
 }
 

--- a/app/components/FarcasterDonationWidget.tsx
+++ b/app/components/FarcasterDonationWidget.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { DONATION_ADDRESS, SUPPORTED_TOKENS } from '../config';
 import { QRCodeSVG as QRCode } from 'qrcode.react';
 import sdk from '@farcaster/frame-sdk';
+import ShareDonationFrame from './ShareDonationFrame';
 
 export default function FarcasterDonationWidget() {
   const [selectedToken, setSelectedToken] = useState('ETH');
@@ -17,6 +18,12 @@ export default function FarcasterDonationWidget() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [frameContext, setFrameContext] = useState<any>(null);
   const [isInFarcasterContext, setIsInFarcasterContext] = useState(false);
+  const [showShareFrame, setShowShareFrame] = useState(false);
+  const [lastDonation, setLastDonation] = useState<{
+    amount: string;
+    asset: string;
+    txHash: string;
+  } | null>(null);
 
   const networks = {
     base: { name: 'Base', chainId: 8453, explorer: 'https://basescan.org', rpcUrl: 'https://mainnet.base.org' },
@@ -237,7 +244,13 @@ export default function FarcasterDonationWidget() {
               }],
             });
 
-            alert(`Transaction sent! Hash: ${txHash}\n\nThank you for your donation of ${amount} ${selectedToken} (≈$${usdEquivalent})!`);
+            // Store donation details and show share frame
+            setLastDonation({
+              amount: amount,
+              asset: selectedToken,
+              txHash: txHash as string
+            });
+            setShowShareFrame(true);
             setAmount('');
             fetchBalance(); // Update balance after transaction
             return;
@@ -273,7 +286,13 @@ export default function FarcasterDonationWidget() {
             }],
           });
 
-          alert(`Transaction sent! Hash: ${txHash}\n\nThank you for your donation of ${amount} ${selectedToken} (≈$${usdEquivalent})!`);
+          // Store donation details and show share frame
+          setLastDonation({
+            amount: amount,
+            asset: selectedToken,
+            txHash: txHash as string
+          });
+          setShowShareFrame(true);
           setAmount('');
           fetchBalance();
         } else {
@@ -297,7 +316,19 @@ export default function FarcasterDonationWidget() {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-lg p-8">
+    <>
+      {/* Share Frame Popup */}
+      {showShareFrame && lastDonation && walletAddress && (
+        <ShareDonationFrame
+          amount={lastDonation.amount}
+          asset={lastDonation.asset}
+          userAddress={walletAddress}
+          txHash={lastDonation.txHash}
+          onClose={() => setShowShareFrame(false)}
+        />
+      )}
+
+      <div className="bg-white rounded-lg shadow-lg p-8">
       <h2 className="text-2xl font-bold mb-6">Make a Donation</h2>
 
       {/* Wallet Connection Status */}
@@ -498,6 +529,7 @@ export default function FarcasterDonationWidget() {
         </div>
       </div>
     </div>
+    </>
   );
 }
 

--- a/app/components/ShareDonationFrame.tsx
+++ b/app/components/ShareDonationFrame.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import sdk from '@farcaster/frame-sdk';
+import html2canvas from 'html2canvas';
+
+interface ShareDonationFrameProps {
+  amount: string;
+  asset: string;
+  userAddress: string;
+  txHash: string;
+  onClose: () => void;
+}
+
+export default function ShareDonationFrame({ 
+  amount, 
+  asset, 
+  userAddress, 
+  txHash,
+  onClose 
+}: ShareDonationFrameProps) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [isSharing, setIsSharing] = useState(false);
+  const [shareSuccess, setShareSuccess] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(false);
+  const frameRef = useRef<HTMLDivElement>(null);
+
+  // Generate frame image on mount
+  useEffect(() => {
+    generateFrameImage();
+  }, []);
+
+  const generateFrameImage = async () => {
+    if (!frameRef.current) return;
+    
+    setIsGenerating(true);
+    try {
+      // Wait a bit for the component to fully render
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
+      const canvas = await html2canvas(frameRef.current, {
+        backgroundColor: '#ffffff',
+        scale: 2,
+        logging: false,
+        useCORS: true,
+        allowTaint: true
+      });
+      
+      const dataUrl = canvas.toDataURL('image/png');
+      setImageDataUrl(dataUrl);
+    } catch (error) {
+      console.error('Error generating frame image:', error);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const shareToFarcaster = async () => {
+    if (!imageDataUrl) {
+      await generateFrameImage();
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      // Check if we're in Farcaster context
+      const context = await sdk.context;
+      
+      if (context) {
+        // Use Farcaster SDK to open composer with the message
+        const message = `🎉 I just donated ${amount} ${asset} to support families in Gaza through @breadchain! 
+
+Every donation helps provide essential food and supplies. Join me in making a difference! 🌍❤️
+
+Transaction: ${txHash.slice(0, 10)}...${txHash.slice(-8)}
+
+Donate: https://farcaster-donate-to-gaza.vercel.app`;
+
+        await sdk.actions.openUrl(
+          `https://warpcast.com/~/compose?text=${encodeURIComponent(message)}`
+        );
+        
+        setShareSuccess(true);
+        setTimeout(() => setShareSuccess(false), 3000);
+      } else {
+        // Fallback for non-Farcaster contexts - open in new window
+        const message = `🎉 I just donated ${amount} ${asset} to support families in Gaza!
+
+Every donation helps provide essential food and supplies. Join me in making a difference! 🌍❤️
+
+Transaction: ${txHash.slice(0, 10)}...${txHash.slice(-8)}`;
+        
+        const url = `https://warpcast.com/~/compose?text=${encodeURIComponent(message)}`;
+        window.open(url, '_blank');
+        
+        setShareSuccess(true);
+        setTimeout(() => setShareSuccess(false), 3000);
+      }
+    } catch (error) {
+      console.error('Error sharing to Farcaster:', error);
+      alert('Failed to share to Farcaster. Please try again.');
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
+  const downloadImage = () => {
+    if (!imageDataUrl) return;
+    
+    const link = document.createElement('a');
+    link.download = `donation-gaza-${Date.now()}.png`;
+    link.href = imageDataUrl;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const copyImageToClipboard = async () => {
+    if (!imageDataUrl) return;
+    
+    try {
+      // Convert data URL to blob
+      const response = await fetch(imageDataUrl);
+      const blob = await response.blob();
+      
+      // Try to use the Clipboard API if available
+      if (typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'image/png': blob
+          })
+        ]);
+        setCopySuccess(true);
+        setTimeout(() => setCopySuccess(false), 2000);
+      } else if (navigator.clipboard?.writeText) {
+        // Fallback: copy the shareable text instead
+        const text = `I just donated ${amount} ${asset} to support families in Gaza! 🌍❤️\nTx: ${txHash}`;
+        await navigator.clipboard.writeText(text);
+        setCopySuccess(true);
+        setTimeout(() => setCopySuccess(false), 2000);
+      } else {
+        alert('Clipboard API not available');
+      }
+    } catch (error) {
+      console.error('Error copying to clipboard:', error);
+      // Fallback to copying text
+      const text = `I just donated ${amount} ${asset} to support families in Gaza! 🌍❤️\nTx: ${txHash}`;
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+          setCopySuccess(true);
+          setTimeout(() => setCopySuccess(false), 2000);
+        }).catch(() => {
+          alert('Unable to copy to clipboard');
+        });
+      } else {
+        alert('Unable to copy to clipboard');
+      }
+    }
+  };
+
+  const formatAddress = (address: string) => {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const formatTxHash = (hash: string) => {
+    return `${hash.slice(0, 10)}...${hash.slice(-8)}`;
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl">
+        {/* Header */}
+        <div className="p-6 border-b border-gray-200">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-gray-900">Thank You for Your Donation! 🎉</h2>
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 text-2xl leading-none"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        {/* Frame Preview */}
+        <div className="p-6">
+          <div className="mb-6">
+            <p className="text-gray-600 mb-4">
+              Your donation is making a real difference! Share your support to inspire others:
+            </p>
+          </div>
+
+          {/* Frame to be captured */}
+          <div className="flex justify-center mb-6">
+            <div 
+              ref={frameRef}
+              className="relative bg-gradient-to-br from-purple-600 to-pink-500 p-8 rounded-xl shadow-xl"
+              style={{ width: '500px', height: '500px' }}
+            >
+              {/* Background pattern */}
+              <div className="absolute inset-0 opacity-10">
+                <div className="absolute inset-0" style={{
+                  backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(255,255,255,.1) 35px, rgba(255,255,255,.1) 70px)`,
+                }}></div>
+              </div>
+
+              {/* Content */}
+              <div className="relative z-10 h-full flex flex-col items-center justify-center text-white text-center">
+                {/* Watermelon emoji as logo */}
+                <div className="text-6xl mb-4">🍉</div>
+                
+                <h3 className="text-3xl font-bold mb-2">I Donated!</h3>
+                
+                <div className="bg-white bg-opacity-20 backdrop-blur rounded-lg p-4 mb-4">
+                  <p className="text-4xl font-bold mb-1">
+                    {amount} {asset}
+                  </p>
+                  <p className="text-sm opacity-90">
+                    to support families in Gaza
+                  </p>
+                </div>
+
+                <div className="space-y-2 text-sm">
+                  <p className="opacity-90">
+                    From: {formatAddress(userAddress)}
+                  </p>
+                  <p className="opacity-90">
+                    Tx: {formatTxHash(txHash)}
+                  </p>
+                </div>
+
+                <div className="mt-6 space-y-1">
+                  <p className="text-lg font-semibold">Every donation matters</p>
+                  <p className="text-sm opacity-90">Join us at breadchain.xyz</p>
+                </div>
+
+                {/* Breadchain branding */}
+                <div className="absolute bottom-4 right-4 flex items-center gap-2 text-xs opacity-75">
+                  <span>Powered by</span>
+                  <span className="font-bold">Breadchain 🍞</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <button
+              onClick={shareToFarcaster}
+              disabled={isSharing || isGenerating}
+              className="flex-1 px-6 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition duration-200 flex items-center justify-center gap-2"
+            >
+              {isSharing ? (
+                <>Sharing...</>
+              ) : shareSuccess ? (
+                <>✓ Shared!</>
+              ) : (
+                <>
+                  <span>🟪</span>
+                  Share to Farcaster
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={downloadImage}
+              disabled={!imageDataUrl || isGenerating}
+              className="flex-1 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition duration-200 flex items-center justify-center gap-2"
+            >
+              <span>⬇️</span>
+              Download Image
+            </button>
+
+            <button
+              onClick={copyImageToClipboard}
+              disabled={!imageDataUrl || isGenerating}
+              className="flex-1 px-6 py-3 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition duration-200 flex items-center justify-center gap-2"
+            >
+              {copySuccess ? (
+                <>✓ Copied!</>
+              ) : (
+                <>
+                  <span>📋</span>
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Additional Info */}
+          <div className="mt-6 p-4 bg-gray-50 rounded-lg">
+            <p className="text-sm text-gray-600 text-center">
+              Your donation helps provide essential food and supplies to families in need. 
+              Thank you for making a difference! 🌍❤️
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@wagmi/core": "^2.6.0",
         "@zoralabs/zdk": "^2.4.0",
         "ethers": "^6.15.0",
+        "html2canvas": "^1.4.1",
         "next": "^14.1.0",
         "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
@@ -5544,6 +5545,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6295,6 +6305,15 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css-what": {
       "version": "6.2.2",
@@ -8193,6 +8212,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -11561,6 +11593,15 @@
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11975,6 +12016,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@wagmi/core": "^2.6.0",
     "@zoralabs/zdk": "^2.4.0",
     "ethers": "^6.15.0",
+    "html2canvas": "^1.4.1",
     "next": "^14.1.0",
     "qrcode.react": "^4.2.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Implements shareable frame popup after successful donations
- Adds Farcaster integration for social sharing
- Includes download and copy functionality for donation frames

## Description
This PR implements the feature requested in issue #12 to allow users to share their donations on Farcaster and other social platforms after completing a donation.

### What's New
- **ShareDonationFrame Component**: A new popup component that displays after successful donations
- **Visual Frame Design**: Beautiful gradient frame with donation details and Gaza support messaging
- **Farcaster Integration**: One-click sharing to Farcaster via Warpcast composer
- **Image Generation**: Converts the frame to a downloadable PNG using html2canvas
- **Multiple Export Options**: Share to Farcaster, download as image, or copy to clipboard

### Implementation Details
- Integrated into both `FarcasterDonationWidget` and `EnhancedDonationWidget`
- Shows donation amount, asset type, wallet address, and transaction hash
- Features watermelon emoji (🍉) as logo and Breadchain branding
- Handles both Farcaster and non-Farcaster contexts gracefully
- Includes proper error handling and fallbacks

### Screenshots
The shareable frame includes:
- Donation amount and asset prominently displayed
- "I Donated\!" headline with watermelon emoji
- Transaction details (wallet address and tx hash)
- Breadchain branding
- Call-to-action to join the cause

## Testing
- [x] Build passes successfully
- [x] Frame popup appears after successful donation
- [x] Farcaster sharing opens Warpcast composer with pre-filled message
- [x] Download functionality generates PNG image
- [x] Copy functionality works with fallback to text

## Closes
Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)